### PR TITLE
Wire parcel reblock

### DIFF
--- a/prclz/cli.py
+++ b/prclz/cli.py
@@ -4,8 +4,9 @@ import click
 
 from .etl import download, split_bldgs
 from .prclz import parcels
-#from .blocks import extract
-#from . import complexity
+from .blocks import extract
+from .reblock import reblock
+from . import complexity
 
 @click.group()
 @click.option("--logging", 
@@ -76,9 +77,42 @@ def complexity(blocks_path, buildings_path, output_dir, overwrite):
     complexity.main(blocks_path, buildings_path, output_dir, overwrite)
 
 @prclz.command()
-def reblock():
+@click.argument("buildings_path",    type = click.Path(exists = True))
+@click.argument("parcels_path", type = click.Path(exists = True))
+@click.argument("blocks_path",     type = click.Path(exists = True))
+@click.argument("output_dir",     type = click.Path(exists = True))
+@click.option("--overwrite", help = "overwrite existing files", default = False, is_flag = True)
+@click.option("--use_width", help = "use width for reblocking estimate", default = False, is_flag = True)
+@click.option("--simplify_roads", help = "simplify reblocked roads", default = False, is_flag = True)
+@click.option("--thru_streets_top_k", help = "connect top-k severe dead ends", default = False, is_flag = True)
+@click.option("--no_progress", help = "don't display reblocking progress", default = True, is_flag = True)
+@click.option("--block_list", help = "specify specific blocks to reblock", default = None)
+def reblock(
+    buildings_path: Union[Path, str], 
+    parcels_path: Union[Path, str], 
+    blocks_path: Union[Path, str], 
+    output_dir: Union[Path, str],
+    overwrite: bool = False,
+    use_width: bool = False, 
+    simplify_roads: bool = False,
+    thru_streets_top_k: Optional[int] = None,
+    no_progress: bool = True,
+    block_list: Optional[List[str]] = None,
+    ):
+    progress = not no_progress
     """ Generate least-cost reblocking network. """
-    pass 
+    reblock.main(buildings_path, 
+                 parcels_path, 
+                 blocks_path, 
+                 output_dir,
+                 overwrite,
+                 use_width, 
+                 simplify_roads,
+                 thru_streets_top_k,
+                 progress,
+                 block_list,
+                 )
+
 
 if __name__ == '__main__':
     prclz()

--- a/prclz/cli.py
+++ b/prclz/cli.py
@@ -3,8 +3,9 @@ from logging import basicConfig, info, debug
 import click
 
 from .etl import download, split_bldgs
-from .blocks import extract
-from . import complexity
+from .prclz import parcels
+#from .blocks import extract
+#from . import complexity
 
 @click.group()
 @click.option("--logging", 
@@ -38,9 +39,9 @@ def split_geojson():
     pass 
 
 @prclz.command()
-@click.argument("--bldg_file", type=str, required=True, help="Path to master geojson file containing all building polygons")
-@click.argument("--gadm_path", type=str, required=True, help="Path to GADM file")
-@click.argument("--output_dir", type=str, required=True, help="Output directory for gadm-specific building files")
+@click.option("--bldg_file", type=str, required=True, help="Path to master geojson file containing all building polygons")
+@click.option("--gadm_path", type=str, required=True, help="Path to GADM file")
+@click.option("--output_dir", type=str, required=True, help="Output directory for gadm-specific building files")
 def split_geojson_bldgs(bldg_file, gadm_path, output_dir):
     """ Split OSM buildings by GADM delineation. """
     split_bldgs.main(bldg_file, gadm_path, output_dir)
@@ -57,9 +58,13 @@ def blocks(gadm_path, linestrings_path, output_dir, gadm_level, overwrite):
     extract.main(gadm_path, linestrings_path, output_dir, gadm_level, overwrite)
 
 @prclz.command()
+@click.argument("blocks_path",    type = click.Path(exists = True))
+@click.argument("buildings_path", type = click.Path(exists = True))
+@click.argument("output_dir",     type = click.Path(exists = True))
+@click.option("--overwrite", help = "overwrite existing files", default = False, is_flag = True)
 def parcels():
     """ Split block into cadastral parcels. """
-    pass 
+    parcels.main(blocks_path, buildings_path, output_dir, overwrite)
 
 @prclz.command()
 @click.argument("blocks_path",    type = click.Path(exists = True))

--- a/prclz/cli.py
+++ b/prclz/cli.py
@@ -62,7 +62,7 @@ def blocks(gadm_path, linestrings_path, output_dir, gadm_level, overwrite):
 @click.argument("buildings_path", type = click.Path(exists = True))
 @click.argument("output_dir",     type = click.Path(exists = True))
 @click.option("--overwrite", help = "overwrite existing files", default = False, is_flag = True)
-def parcels():
+def parcels(blocks_path, buildings_path, output_dir, overwrite):
     """ Split block into cadastral parcels. """
     parcels.main(blocks_path, buildings_path, output_dir, overwrite)
 

--- a/prclz/prclz/parcels.py
+++ b/prclz/prclz/parcels.py
@@ -265,6 +265,7 @@ def get_bad_geoms(
     return bad_parcels, bad_bldgs
 
 
+
 if __name__ == "__main__":
 
 

--- a/prclz/prclz/parcels.py
+++ b/prclz/prclz/parcels.py
@@ -144,7 +144,7 @@ def find_parent_parcel_id(parcel: Polygon,
         bid = None 
         # NOTE: this does not imply failure, as many orphaned polys
         # are in areas w/o any buildings at all
-        info("Could not match orphaned parcel with centroid %sto neighboring parcel", centroid)
+        info("Could not match orphaned parcel with centroid %s to neighboring parcel", centroid)
 
     return bid
 
@@ -206,10 +206,7 @@ def main(
             parcels_gdf = make_parcels(bldgs, block)
             parcels_gdf['block_id'] = block_id
             all_parcels.append(parcels_gdf)
-            # if i == 0:
-            #     parcels_gdf = make_parcels(bldgs, block)
-            # else:
-            #     parcels_gdf = pd.concat([parcels_gdf, make_parcels(bldgs, block)])
+
         parcels_gdf = pd.concat(all_parcels)
         parcels_gdf.drop(columns=['uID'], inplace=True)
         parcels_gdf.to_file(output_path, driver='GeoJSON')

--- a/prclz/reblock/planar_graph.py
+++ b/prclz/reblock/planar_graph.py
@@ -235,8 +235,33 @@ class PlanarGraph(igraph.Graph):
         return graph
 
     @classmethod
+    def from_shapely(cls: Type,
+                     geom: Union[MultiPolygon, MultiLineString],
+                     ) -> PlanarGraph:
+        """
+        Convenience method for calling the appropriate constructor
+        based on the geomtype of geom
+        """
+        if isinstance(geom, MultiPolygon):
+            graph = cls.from_multipolygon(geom)
+        elif isinstance(geom, MultiLineString):
+            graph = cls.from_multilinestring(geom)
+        else:
+            if isinstance(geom, gpd.GeoSeries):
+                geom0 = geom.iloc[0]
+            else:
+                geom0 = geom[0]
+            if isinstance(geom0, Polygon):
+                graph = cls.from_multipolygon(geom)
+            elif isinstance(geom0, LineString):
+                graph = cls.from_multilinestring(geom)
+            else:
+                raise RuntimeError("Attempted creation of internal graph class with geom type {}".format(type(geom)))
+        return graph 
+
+    @classmethod
     def from_multipolygon(cls: Type, 
-                          multipolygon: MultiPolygon,
+                          multipolygon: Union[MultiPolygon, Sequence[Polygon]],
                           ) -> PlanarGraph:
         """
         Factory method for creating a graph representation of 
@@ -261,7 +286,7 @@ class PlanarGraph(igraph.Graph):
 
     @classmethod
     def from_multilinestring(cls: Type, 
-                             multilinestring: MultiLineString,
+                             multilinestring: Union[MultiLineString, Sequence[LineString]],
                              ) -> PlanarGraph:
         """
         Factory method for creating a graph representation of 

--- a/prclz/reblock/planar_graph.py
+++ b/prclz/reblock/planar_graph.py
@@ -615,7 +615,6 @@ class PlanarGraph(igraph.Graph):
 
         if total_blgds > 0:
             self._cleanup_linestring_attr()
-        #return graph 
 
     def clean_graph(self) -> PlanarGraph:
         """
@@ -625,6 +624,7 @@ class PlanarGraph(igraph.Graph):
         is_conn = self.is_connected()
         if is_conn:
             num_components = 1
+            new_graph = self
         else:
             components = self.components(mode=igraph.WEAK)
             num_components = len(components)
@@ -632,9 +632,10 @@ class PlanarGraph(igraph.Graph):
             arg_max = np.argmax(comp_sizes)
             comp_indices = components[arg_max]
         
-            self = self.subgraph(comp_indices)
+            #self = self.subgraph(comp_indices)
+            new_graph = self.subgraph(comp_indices)
         info("Graph contains %s components", num_components)
-        return num_components
+        return num_components, new_graph
 
     def update_edge_types(self, 
                           block_polygon: Polygon, 
@@ -658,7 +659,17 @@ class PlanarGraph(igraph.Graph):
             Updates graph in place. Returns summary of matching
             check between parcel and block
         """
-        block_coords_list = list(block_polygon.exterior.coords)
+        if isinstance(block_polygon, Polygon):
+            block_coords_list = list(block_polygon.exterior.coords)
+        elif isinstance(block_polygon, LineString):
+            block_coords_list = list(block_polygon.coords)
+        elif isinstance(block_polygon, MultiLineString):
+            block_coords_list = []
+            for b in block_polygon:
+                block_coords_list.extend(list(b.coords))
+        else:
+            block_coords_list = list(block_polygon.exterior.coords)
+            #raise RuntimeError("In PlanarGraph.update_edge_types block_polygon type = {} but should be LineString or Polygon".format(type(block_polygon)))    
         coords = set(block_coords_list)
 
         rv = (None, None)
@@ -678,7 +689,7 @@ class PlanarGraph(igraph.Graph):
                 warning("%s of %s block coords are NOT in the parcel coords", missing, total)
 
         # Get list of coord_tuples from the polygon
-        assert block_coords_list[0] == block_coords_list[-1], "Not a complete linear ring for polygon"
+        #assert block_coords_list[0] == block_coords_list[-1], "Not a complete linear ring for polygon"
 
         # Loop over the block coords (as define an edge) and update the corresponding edge type in the graph accordingly
         # NOTE: every block coord will be within the parcel graph vertices
@@ -725,7 +736,7 @@ class PlanarGraph(igraph.Graph):
 
         # Now get the MST of that complete graph of only terminal_vertices
         if "weight" not in H.es.attributes():
-            error("----H graph does not have weight, ERROR There are %s", len(terminal_vertices))
+            error("----H graph does not have weight, ERROR There are %s terminal vertices", len(terminal_vertices))
         mst_edge_idxs = H.spanning_tree(weights='weight', return_tree=False)
 
         # Now, we join the paths for all the mst_edge_idxs
@@ -1185,7 +1196,6 @@ class PlanarGraph(igraph.Graph):
             del self.es['edge_type']
 
     def simplify_reblocked_graph(self):
-
         # Extract the optimal subgraph of new lines only
         def filter(edge) -> bool:
             if 'is_through_line' in edge.attributes():
@@ -1205,7 +1215,6 @@ class PlanarGraph(igraph.Graph):
 
             # And fetch the buffer area based on the width across 
             # that linestring/edge-sequence  
-
             edge_linestring, _, admiss_region, _ = opt_subgraph.get_steiner_linestrings(expand=False, return_polys=True, edge_seq=edges)
             edge_linestring = linemerge(edge_linestring)
 
@@ -1213,25 +1222,3 @@ class PlanarGraph(igraph.Graph):
             simplified_linestrings.append(simplified_linestring)
         return simplified_linestrings      
 
-
-# def convert_to_lines(planar_graph) -> MultiLineString:
-#     lines = [LineString(planar_graph.edge_to_coords(e)) for e in planar_graph.es]
-#     multi_line = unary_union(lines)
-#     return multi_line 
-
-
-# def find_edge_from_coords(g, coord0, coord1):
-#     '''
-#     Given a pair of coordinates, checks whether the graph g
-#     contains an edge between that coordinate pair
-#     '''
-#     v0 = g.vs.select(name_eq=coord0)
-#     v1 = g.vs.select(name_eq=coord1)
-#     if len(v0)==0 or len(v1)==0:
-#         return None 
-#     else:
-#         edge = g.es.select(_between=(v0, v1))
-#         if len(edge)==0:
-#             return None 
-#         else:
-#             return edge[0]

--- a/prclz/utils.py
+++ b/prclz/utils.py
@@ -61,7 +61,7 @@ def csv_to_geo(csv_path, add_file_col=False):
         f = csv_path.split("/")[-1]
         df['gadm_code'] = f.replace("blocks_", "").replace(".csv", "")
 
-    return gpd.GeoDataFrame(df, geometry='block_geom')
+    return gpd.GeoDataFrame(df, geometry='block_geom', crs='EPSG:4326')
 
 def load_geopandas_files(region: str, gadm_code: str, gadm: str) -> Tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]:
 


### PR DESCRIPTION
Reblocking relies on parcelization so as we changed the latter to use momepy I've adjusted the former to be robust to both parcelization types. I've done some final testing of the various reblocking options (width, thru lines, simplification) to make sure everything is running smoothly. The vanilla reblocking runs through fine on ~500+ DJI blocks. The options are more compute intensive but are working as expected on the few that I could run locally. 

I've wired everything through the CLI although I was having really weird behavior with the cli and couldn't get anything to run -- the Path args always return an error that they don't exist and If i remove the exist precondition they get passed in as a weird string literal and it's a mess. I'm not sure what the deal is but the coding of the wiring is straightforward and I've recreated what as already there.
